### PR TITLE
Changed python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11.3
 RUN mkdir /code 
 COPY . /code
 COPY pyproject.toml /code

--- a/hsc-chart/values.yaml
+++ b/hsc-chart/values.yaml
@@ -50,7 +50,7 @@ pod:
   name: hsc
   container:
     name: health-status-calculator-app
-    image: prithvirana/training:v36
+    image: prithvirana/training:v38
     ports:
       - containerPort: 80
   serviceAccount:
@@ -72,7 +72,7 @@ replicaCount: 1
 
 image:
   repository: prithvirana/training
-  tag: v36
+  tag: v38
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Upgraded Python version from 3.8 to 3.11.3. in order to try to fix vulnerabilities. But that did not work. 
Pinned requests = "2.31.0" and starlette = "0.27.0" based on snyk suggestions to fix two vulnerabilities. 
No direct fix available via snyk for other vulnerabilities. Snyk suggests upgrading to python version python:3.12-rc-slim. This version is not compatible with packages that are needed for the project. 

Critical vulnerabilities 
aom/libaom0 Buffer Overflow 
Introduced through: python@3.8 › aom/libaom0@1.0.0.errata1-3
Fix: No remediation path available

aom/libaom0 Release of Invalid Pointer or Reference

aom/libaom0 Use After Free

curl Cleartext Transmission of Sensitive Information

Critical : 4, High : 3, Medium: 3, Low: 242

These vulnerabilities seem to come from Python 3.8 depending on libraries with vulnerabilities. 

